### PR TITLE
add jacoco coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: java
-script: mvn -Drandomized.multiplier=10 clean verify
+
+sudo: false
+
+script: mvn -Drandomized.multiplier=10 clean verify jacoco:report
+
 jdk:
   - openjdk7
   - oraclejdk8
   - oraclejdk7
+
 notifications:
   email:
     - spatial4j-dev@locationtech.org
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ notifications:
     - spatial4j-dev@locationtech.org
 
 after_success:
+  - du -hs target/site/jacoco/jacoco.xml
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build](https://travis-ci.org/locationtech/spatial4j.svg)](https://travis-ci.org/locationtech/spatial4j)
 [![Coverage](https://img.shields.io/codecov/c/github/locationtech/spatial4j.svg)](https://travis-ci.org/locationtech/spatial4j)
 [![Maven](https://img.shields.io/maven-central/v/com.spatial4j/spatial4j.svg)](https://maven-badges.herokuapp.com/maven-central/com.spatial4j/spatial4j/)
-[![License](https://img.shields.io/github/license/locationtech/spatial4j.svg)](LICENSE)
+[![License](https://img.shields.io/github/license/locationtech/spatial4j.svg)](LICENSE.txt)
 
 
 Spatial4j is a general purpose spatial / geospatial [ASL](http://www.apache.org/licenses/LICENSE-2.0.html) licensed open-source Java library. It's core capabilities are 3-fold: to provide common shapes that can work in Euclidean and geodesic (surface of sphere) world models, to provide distance calculations and other math, and to read shapes from [WKT](http://en.wikipedia.org/wiki/Well-known_text) formatted strings.  Spatial4j is a member of the [LocationTech](http://www.locationtech.org) Industry Working Group family of projects.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spatial4j
 
 [![Build](https://travis-ci.org/locationtech/spatial4j.svg)](https://travis-ci.org/locationtech/spatial4j)
-[![Coverage](https://img.shields.io/codecov/c/github/locationtech/spatial4j.svg)](https://travis-ci.org/locationtech/spatial4j)
+[![Coverage](https://img.shields.io/codecov/c/github/locationtech/spatial4j.svg)](https://codecov.io/github/locationtech/spatial4j/)
 [![Maven](https://img.shields.io/maven-central/v/com.spatial4j/spatial4j.svg)](https://maven-badges.herokuapp.com/maven-central/com.spatial4j/spatial4j/)
 [![License](https://img.shields.io/github/license/locationtech/spatial4j.svg)](LICENSE.txt)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Spatial4j
 
 [![Build](https://travis-ci.org/locationtech/spatial4j.svg)](https://travis-ci.org/locationtech/spatial4j)
+[![Coverage](https://img.shields.io/codecov/c/github/locationtech/spatial4j.svg)](https://travis-ci.org/locationtech/spatial4j)
+[![Maven](https://img.shields.io/maven-central/v/com.spatial4j/spatial4j.svg)](https://maven-badges.herokuapp.com/maven-central/com.spatial4j/spatial4j/)
+[![License](https://img.shields.io/github/license/locationtech/spatial4j.svg)](LICENSE)
+
 
 Spatial4j is a general purpose spatial / geospatial [ASL](http://www.apache.org/licenses/LICENSE-2.0.html) licensed open-source Java library. It's core capabilities are 3-fold: to provide common shapes that can work in Euclidean and geodesic (surface of sphere) world models, to provide distance calculations and other math, and to read shapes from [WKT](http://en.wikipedia.org/wiki/Well-known_text) formatted strings.  Spatial4j is a member of the [LocationTech](http://www.locationtech.org) Industry Working Group family of projects.
 

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.3</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
@@ -172,7 +172,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
+        <version>2.6</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -197,13 +197,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18</version>
+        <version>2.18.1</version>
       </plugin>
 
       <plugin>
         <groupId>de.thetaphi</groupId>
         <artifactId>forbiddenapis</artifactId>
-        <version>1.7</version>
+        <version>1.8</version>
         <executions>
           <execution>
             <goals>
@@ -231,7 +231,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.4</version>
         <configuration>
           <instructions>
             <Export-Package>com.spatial4j.core*;version=${project.version}</Export-Package>
@@ -243,13 +243,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.4</version>
       </plugin>
 
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.2.201409121644</version>
+        <version>0.7.5.201505241946</version>
         <executions>
           <execution>
             <id>prepare-agent</id>
@@ -286,13 +286,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.8</version>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.5</version>
         <configuration>
           <linkXRef>true</linkXRef>
           <minimumTokens>100</minimumTokens>
@@ -304,7 +304,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.5.3</version>
+        <version>2.5.5</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
         </configuration>
@@ -313,7 +313,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jxr-plugin</artifactId>
-        <version>2.4</version>
+        <version>2.5</version>
         <!-- we exclude tests: -->
         <reportSets>
           <reportSet>
@@ -327,13 +327,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.16</version>
+        <version>2.18.1</version>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>2.10.3</version>
         <configuration>
           <header>Spatial4j, ${project.version}</header>
           <footer>Spatial4j, ${project.version}</footer>

--- a/pom.xml
+++ b/pom.xml
@@ -197,13 +197,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.16</version>
-        <configuration>
-          <!-- This is a small project that should have no problem with tests
-          running in the maven JVM. This also conveniently means system
-          properties pass through. -->
-          <forkCount>0</forkCount>
-        </configuration>
+        <version>2.18</version>
       </plugin>
 
       <plugin>
@@ -250,6 +244,20 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <version>3.3</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.2.201409121644</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <!-- http://blog.progs.be/517/publishing-javadoc-to-github-using-maven -->


### PR DESCRIPTION
This adds the jacoco coverage repots.  The only tradeoff is that maven-surefire-plugin needs to fork the processes.

(there was a comment about not wanting to do that, but i don’t know if that is a real issue or not)