### PR TITLE
Ensuring point coordinates not encoded as nested array.

### DIFF
--- a/src/main/java/com/spatial4j/core/io/jts/JtsGeoJSONWriter.java
+++ b/src/main/java/com/spatial4j/core/io/jts/JtsGeoJSONWriter.java
@@ -99,7 +99,7 @@ public class JtsGeoJSONWriter extends GeoJSONWriter {
     if (geom instanceof Point) {
       Point v = (Point) geom;
       output.append("{\"type\":\"Point\",\"coordinates\":");
-      write(output, nf, v.getCoordinateSequence());
+      write(output, nf, v.getCoordinate());
       output.append("}");
       return;
     } else if (geom instanceof Polygon) {

--- a/src/test/java/com/spatial4j/core/io/jts/JtsGeoJSONWriterTest.java
+++ b/src/test/java/com/spatial4j/core/io/jts/JtsGeoJSONWriterTest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Voyager Search
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ *    http://www.apache.org/licenses/LICENSE-2.0.txt
+ ******************************************************************************/
+
+package com.spatial4j.core.io.jts;
+
+import com.spatial4j.core.context.jts.JtsSpatialContext;
+import com.vividsolutions.jts.geom.Geometry;
+import io.jeo.geom.Geom;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import static org.junit.Assert.assertEquals;
+
+public class JtsGeoJSONWriterTest {
+
+    JtsGeoJSONWriter writer;
+
+    @Before
+    public void setUp() {
+        writer = new JtsGeoJSONWriter(JtsSpatialContext.GEO, null);
+    }
+
+    @Test
+    public void testWritePoint() throws IOException {
+        String out = write(Geom.point(1, 2));
+        assertEquals("{'type':'Point','coordinates':[1,2]}", out);
+    }
+
+    String write(Geometry geom) throws IOException {
+        StringWriter w = new StringWriter();
+        writer.write(w, geom);
+        return w.toString().replaceAll("\"", "'").replaceAll("\\s*", "");
+    }
+}


### PR DESCRIPTION
Currently the jts geojson encoder produces an invalid point that has an extra array around the coordinates. 

    {
      "type": "Point", 
      "coordinates": [ [1, 2] ]
    }
