### PR TITLE
RoundTripIssues

### DIFF
--- a/src/main/java/com/spatial4j/core/io/jts/JtsGeoJSONReader.java
+++ b/src/main/java/com/spatial4j/core/io/jts/JtsGeoJSONReader.java
@@ -100,28 +100,6 @@ public class JtsGeoJSONReader extends GeoJSONReader {
   }
 
   @Override
-  protected Shape readLineString(JSONParser parser) throws IOException, ParseException {
-    assert (parser.lastEvent() == JSONParser.ARRAY_START);
-    List<Coordinate> coords = readCoordList(parser);
-
-    GeometryFactory factory = ctx.getGeometryFactory();
-    CoordinateSequence seq =
-        factory.getCoordinateSequenceFactory()
-            .create(coords.toArray(new Coordinate[coords.size()]));
-
-    LineString geo = ctx.getGeometryFactory().createLineString(seq);
-    Shape shp = ctx.makeShape(geo);
-
-    // check for buffer
-    double buf = readDistance(BUFFER, BUFFER_UNITS, parser);
-    if (buf != 0d) {
-      shp = shp.getBuffered(buf, ctx);
-    }
-
-    return shp;
-  }
-
-  @Override
   protected Shape readPolygon(JSONParser parser) throws IOException, ParseException {
     assert (parser.lastEvent() == JSONParser.ARRAY_START);
     GeometryFactory gf = ctx.getGeometryFactory();

--- a/src/test/java/com/spatial4j/core/io/BaseRoundTripTest.java
+++ b/src/test/java/com/spatial4j/core/io/BaseRoundTripTest.java
@@ -8,15 +8,12 @@
 
 package com.spatial4j.core.io;
 
-import java.text.ParseException;
-import java.util.Arrays;
-
-import org.junit.Test;
-
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.spatial4j.core.context.SpatialContext;
 import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.ShapeCollection;
+import org.junit.Test;
+
+import java.text.ParseException;
 
 public abstract class BaseRoundTripTest<T extends SpatialContext> extends RandomizedTest {
 
@@ -38,7 +35,7 @@ public abstract class BaseRoundTripTest<T extends SpatialContext> extends Random
   // using floats instead of doubles, and WKT is normalized whereas ctx.makeXXX is not.
 
   @Test
-  public void testPoint() {
+  public void testPoint() throws Exception {
     assertRoundTrip(wkt("POINT(-10 80.3)"));
   }
 
@@ -59,9 +56,9 @@ public abstract class BaseRoundTripTest<T extends SpatialContext> extends Random
     }
   }
 
-  protected final void assertRoundTrip(Shape shape) {
+  protected final void assertRoundTrip(Shape shape) throws Exception {
     assertRoundTrip(shape, shouldBeEqualAfterRoundTrip()); 
   }
 
-  protected abstract void assertRoundTrip(Shape shape, boolean andEquals);
+  protected abstract void assertRoundTrip(Shape shape, boolean andEquals) throws Exception;
 }

--- a/src/test/java/com/spatial4j/core/io/BinaryCodecTest.java
+++ b/src/test/java/com/spatial4j/core/io/BinaryCodecTest.java
@@ -8,18 +8,13 @@
 
 package com.spatial4j.core.io;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.Arrays;
-
-import org.junit.Test;
-
 import com.spatial4j.core.context.SpatialContext;
 import com.spatial4j.core.shape.Shape;
 import com.spatial4j.core.shape.ShapeCollection;
+import org.junit.Test;
+
+import java.io.*;
+import java.util.Arrays;
 
 public class BinaryCodecTest extends BaseRoundTripTest<SpatialContext> {
 
@@ -29,17 +24,17 @@ public class BinaryCodecTest extends BaseRoundTripTest<SpatialContext> {
   }
 
   @Test
-  public void testRect() {
+  public void testRect() throws Exception {
     assertRoundTrip(wkt("ENVELOPE(-10, 180, 42.3, 0)"));
   }
 
   @Test
-  public void testCircle() {
+  public void testCircle() throws Exception {
     assertRoundTrip(wkt("BUFFER(POINT(-10 30), 5.2)"));
   }
 
   @Test
-  public void testCollection() {
+  public void testCollection() throws Exception {
     ShapeCollection s = ctx.makeCollection(
         Arrays.asList(
             randomShape(),
@@ -51,15 +46,11 @@ public class BinaryCodecTest extends BaseRoundTripTest<SpatialContext> {
   }
 
   @Override
-  protected void assertRoundTrip(Shape shape, boolean andEquals) {
-    try {
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      binaryCodec.writeShape(new DataOutputStream(baos), shape);
-      ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-      assertEquals(shape, binaryCodec.readShape(new DataInputStream(bais)));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+  protected void assertRoundTrip(Shape shape, boolean andEquals) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    binaryCodec.writeShape(new DataOutputStream(baos), shape);
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    assertEquals(shape, binaryCodec.readShape(new DataInputStream(bais)));
   }
 
 }

--- a/src/test/java/com/spatial4j/core/io/GeneralGeoJSONTest.java
+++ b/src/test/java/com/spatial4j/core/io/GeneralGeoJSONTest.java
@@ -88,18 +88,18 @@ public class GeneralGeoJSONTest extends GeneralReadWriteShapeTest {
 
   @Test
   public void testParseLineString() throws Exception {
-    assertTrue(line().equals(reader.read(lineText())));
+    assertEquals(line(), reader.read(lineText()));
   }
 
   @Test
   public void testEncodeLineString() throws Exception {
-    assertEquals(lineText(), writer.toString(line()));
+    assertEquals(lineText(), strip(writer.toString(line())));
   }
 
   @Test
   public void testParsePolygon() throws Exception {
-    assertTrue(polygon1().equals(reader.read(polygonText1())));
-    assertTrue(polygon2().equals(reader.read(polygonText2())));
+    assertEquals(polygon1(), reader.read(polygonText1()));
+    assertEquals(polygon2(), reader.read(polygonText2()));
   }
 
   @Test
@@ -110,7 +110,7 @@ public class GeneralGeoJSONTest extends GeneralReadWriteShapeTest {
 
   @Test
   public void testParseMultiPoint() throws Exception {
-    assertTrue(multiPoint().equals(reader.read(multiPointText())));
+    assertEquals(multiPoint(), reader.read(multiPointText()));
   }
 
   @Test
@@ -120,7 +120,7 @@ public class GeneralGeoJSONTest extends GeneralReadWriteShapeTest {
 
   @Test
   public void testParseMultiLineString() throws Exception {
-    assertTrue(multiLine().equals(reader.read(multiLineText())));
+    assertEquals(multiLine(), reader.read(multiLineText()));
   }
 
   @Test
@@ -130,7 +130,7 @@ public class GeneralGeoJSONTest extends GeneralReadWriteShapeTest {
 
   @Test
   public void testParseMultiPolygon() throws Exception {
-    assertTrue(multiPolygon().equals(reader.read(multiPolygonText())));
+    assertEquals(multiPolygon(), reader.read(multiPolygonText()));
   }
 
   @Test

--- a/src/test/java/com/spatial4j/core/io/GeneralGeoJSONTest.java
+++ b/src/test/java/com/spatial4j/core/io/GeneralGeoJSONTest.java
@@ -58,17 +58,17 @@ public class GeneralGeoJSONTest extends GeneralReadWriteShapeTest {
   protected ShapeWriter getShapeWriterForTests() {
     return writerForTests;
   }
-  
 
-  @Test
-  public void testCircle() {
-    assertRoundTrip(wkt("BUFFER(POINT(-10 30), 40)"), false);
+  @Test @Override
+  public void testWriteThenReadCircle() throws Exception {
+    //don't test shape equality; rounding issue in 'km' conversion
+    assertRoundTrip(circle(), false);
   }
 
-  @Override
+  @Test @Override
   public void testWriteThenReadBufferedLine() throws Exception {
-    // jts context leads jts LineString buffered to a polygon, rather than a BufferedLineString 
-    assertTrue(getShapeReader().read(getShapeWriter().toString(bufferedLine())).hasArea());
+    //don't test shape equality; rounding issue in 'km' conversion
+    assertRoundTrip(bufferedLine(), false);
   }
 
   //

--- a/src/test/java/com/spatial4j/core/io/GeneralPolyshapeTest.java
+++ b/src/test/java/com/spatial4j/core/io/GeneralPolyshapeTest.java
@@ -17,16 +17,8 @@
 
 package com.spatial4j.core.io;
 
-import java.io.IOException;
-import java.text.ParseException;
-
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Test;
-
-import com.spatial4j.core.exception.InvalidShapeException;
-import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.impl.GeoCircle;
 
 public class GeneralPolyshapeTest extends GeneralReadWriteShapeTest {
 
@@ -68,9 +60,5 @@ public class GeneralPolyshapeTest extends GeneralReadWriteShapeTest {
   public boolean shouldBeEqualAfterRoundTrip() {
     return false; // the polyline values will be off by a small fraction -- everything is rounded to: Math.round(value * 1e5)
   }
-  
-  @Test
-  public void testCircle() {
-    assertRoundTrip(wkt("BUFFER(POINT(-10 30), 40)"));
-  }
+
 }

--- a/src/test/java/com/spatial4j/core/io/GeneralPolyshapeTest.java
+++ b/src/test/java/com/spatial4j/core/io/GeneralPolyshapeTest.java
@@ -42,7 +42,7 @@ public class GeneralPolyshapeTest extends GeneralReadWriteShapeTest {
     
     reader = ctx.getFormats().getReader(ShapeIO.POLY);
     writer = ctx.getFormats().getWriter(ShapeIO.POLY);
-    writerForTests = ctx.getFormats().getWriter(ShapeIO.GeoJSON);
+    writerForTests = writer;
 
     Assert.assertNotNull(reader);
     Assert.assertNotNull(writer);

--- a/src/test/java/com/spatial4j/core/io/GeneralReadWriteShapeTest.java
+++ b/src/test/java/com/spatial4j/core/io/GeneralReadWriteShapeTest.java
@@ -19,7 +19,6 @@ package com.spatial4j.core.io;
 
 import com.spatial4j.core.context.jts.JtsSpatialContext;
 import com.spatial4j.core.context.jts.JtsSpatialContextFactory;
-import com.spatial4j.core.exception.InvalidShapeException;
 import com.spatial4j.core.shape.Rectangle;
 import com.spatial4j.core.shape.Shape;
 import io.jeo.geom.GeomBuilder;
@@ -27,8 +26,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.text.ParseException;
 import java.util.Arrays;
 
 public abstract class GeneralReadWriteShapeTest extends BaseRoundTripTest<JtsSpatialContext> {
@@ -57,24 +54,16 @@ public abstract class GeneralReadWriteShapeTest extends BaseRoundTripTest<JtsSpa
   protected abstract ShapeWriter getShapeWriterForTests();
   
   @Override
-  protected void assertRoundTrip(Shape shape, boolean andEquals) {
-    try {
-      String str = getShapeWriter().toString(shape);
-      Shape out = getShapeReader().read(str);
+  protected void assertRoundTrip(Shape shape, boolean andEquals) throws Exception {
+    String str = getShapeWriter().toString(shape);
+    Shape out = getShapeReader().read(str);
 
-      // GeoJSON has limited numberic precision so the off by .0000001 does not affect its equals
-      ShapeWriter writer = getShapeWriterForTests();
-      Assert.assertEquals(writer.toString(shape), writer.toString(out));
-      
-      if(andEquals) {
-        Assert.assertEquals(shape, out);
-      }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    } catch (InvalidShapeException e) {
-      throw new RuntimeException(e);
-    } catch (ParseException e) {
-      throw new RuntimeException(e);
+    // GeoJSON has limited numeric precision so the off by .0000001 does not affect its equals
+    ShapeWriter writer = getShapeWriterForTests();
+    Assert.assertEquals(writer.toString(shape), writer.toString(out));
+
+    if(andEquals) {
+      Assert.assertEquals(shape, out);
     }
   }
   
@@ -126,7 +115,7 @@ public abstract class GeneralReadWriteShapeTest extends BaseRoundTripTest<JtsSpa
 
   @Test
   public void testWriteThenReadCircle() throws Exception {
-    assertRoundTrip(circle(), false);
+    assertRoundTrip(circle());
   }
 
   String pointText() {
@@ -183,7 +172,7 @@ public abstract class GeneralReadWriteShapeTest extends BaseRoundTripTest<JtsSpa
   Shape multiPoint() {
     return ctx.makeShape(gb.points(100.1, 0.1, 101.1, 1.1).toMultiPoint());
   }
-  
+
 
   String multiLineText() {
     return strip(
@@ -199,7 +188,7 @@ public abstract class GeneralReadWriteShapeTest extends BaseRoundTripTest<JtsSpa
     return ctx.makeShape(gb.points(100.1, 0.1, 101.1, 1.1).lineString()
       .points(102.1, 2.1, 103.1, 3.1).lineString().toMultiLineString());
   }
-  
+
   String multiPolygonText() {
     return strip(
     "{ 'type': 'MultiPolygon',"+

--- a/src/test/java/com/spatial4j/core/io/GeneralReadWriteShapeTest.java
+++ b/src/test/java/com/spatial4j/core/io/GeneralReadWriteShapeTest.java
@@ -27,9 +27,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.Arrays;
 
 public abstract class GeneralReadWriteShapeTest extends BaseRoundTripTest<JtsSpatialContext> {
 
@@ -46,6 +46,7 @@ public abstract class GeneralReadWriteShapeTest extends BaseRoundTripTest<JtsSpa
     JtsSpatialContextFactory factory = new JtsSpatialContextFactory();
     factory.geo = true;
     factory.normWrapLongitude = true;
+    factory.useJtsLineString = false; // false so that buffering lineString round-trips
     return new JtsSpatialContext(factory);
   }
   
@@ -142,7 +143,7 @@ public abstract class GeneralReadWriteShapeTest extends BaseRoundTripTest<JtsSpa
   }
 
   Shape line() {
-    return ctx.makeShape(gb.points(100.1, 0.1, 101.1,1.1).toLineString());
+    return ctx.makeLineString(Arrays.asList(ctx.makePoint(100.1, 0.1), ctx.makePoint(101.1, 1.1)));
   }
 
   Shape polygon1() {
@@ -180,7 +181,7 @@ public abstract class GeneralReadWriteShapeTest extends BaseRoundTripTest<JtsSpa
   }
 
   Shape multiPoint() {
-    return ctx.makeShape( gb.points(100.1, 0.1, 101.1, 1.1).toMultiPoint() );
+    return ctx.makeShape(gb.points(100.1, 0.1, 101.1, 1.1).toMultiPoint());
   }
   
 

--- a/src/test/java/com/spatial4j/core/io/GeneralWktTest.java
+++ b/src/test/java/com/spatial4j/core/io/GeneralWktTest.java
@@ -58,12 +58,6 @@ public class GeneralWktTest extends GeneralReadWriteShapeTest {
     return writerForTests;
   }
 
-  @Override
-  public void testWriteThenReadBufferedLine() throws Exception {
-    // jts context leads jts LineString buffered to a polygon, rather than a BufferedLineString
-    assertTrue(getShapeReader().read(getShapeWriter().toString(bufferedLine())).hasArea());
-  }
-
   //TODO: Either the WKT read/writer should try to flatten to the original type (not GeometryCollection)
   //  and/or ShapeCollection needs to become typed.
 


### PR DESCRIPTION
There are some round-trip issues we should address, mainly around buffered line string.
Note that GeoJSON format is *not* honoring the useJtsLineString setting.