### PR TITLE
optimize line string

### DIFF
--- a/src/main/java/org/locationtech/spatial4j/shape/jts/JtsGeometry.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/jts/JtsGeometry.java
@@ -20,6 +20,7 @@ import org.locationtech.spatial4j.shape.impl.RectangleImpl;
 import com.vividsolutions.jts.geom.*;
 import com.vividsolutions.jts.geom.prep.PreparedGeometry;
 import com.vividsolutions.jts.geom.prep.PreparedGeometryFactory;
+import com.vividsolutions.jts.geom.prep.PreparedLineString;
 import com.vividsolutions.jts.operation.union.UnaryUnionOp;
 import com.vividsolutions.jts.operation.valid.IsValidOp;
 
@@ -234,8 +235,16 @@ public class JtsGeometry extends BaseShape<JtsSpatialContext> {
     SpatialRelation bboxR = bbox.relate(rectangle);
     if (bboxR == SpatialRelation.WITHIN || bboxR == SpatialRelation.DISJOINT)
       return bboxR;
-    // FYI, the right answer could still be DISJOINT or WITHIN, but we don't know yet.
-    return relate(ctx.getGeometryFrom(rectangle));
+
+    // FYI, the right answer could still be DISJOINT, but cannot be WITHIN.
+
+    Geometry rectangleGeom = ctx.getGeometryFrom(rectangle);
+    if (!rectangle.isEmpty() && preparedGeometry instanceof PreparedLineString) {
+      // We know linestring cannot contain a rectangle so we just need to check for intersects.
+      return preparedGeometry.intersects(rectangleGeom) ? SpatialRelation.INTERSECTS : SpatialRelation.DISJOINT;
+    }
+
+    return relate(rectangleGeom);
   }
 
   public SpatialRelation relate(final Circle circle) {


### PR DESCRIPTION
Elastic search uses this method to compute it's indexes.  For line strings that are very long, this method will be called once for each 50m that the line string covers (50m is the default, but basically one call to relate() for each lowest bucket level distance).

In my profiling I have identified that 100% of the time is spent in the covers case.  However, a line will never cover a rectangle.

It isn't needed to accept this patch as is because I'm sure there is a better way to accomplish this perf optimization. 