### PR TITLE
Move auto index logic to makeShape().

### DIFF
--- a/src/main/java/org/locationtech/spatial4j/shape/jts/JtsGeometry.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/jts/JtsGeometry.java
@@ -130,6 +130,13 @@ public class JtsGeometry extends BaseShape<JtsSpatialContext> {
   }
 
   /**
+   * Determines if the shape has been indexed.
+   */
+  boolean isIndexed() {
+    return preparedGeometry != null;
+  }
+
+  /**
    * Adds an index to this class internally to compute spatial relations faster. In JTS this
    * is called a {@link com.vividsolutions.jts.geom.prep.PreparedGeometry}.  This
    * isn't done by default because it takes some time to do the optimization, and it uses more

--- a/src/main/java/org/locationtech/spatial4j/shape/jts/JtsShapeFactory.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/jts/JtsShapeFactory.java
@@ -503,8 +503,6 @@ public class JtsShapeFactory extends ShapeFactoryImpl {
         throw e;
       }
     }
-    if (isAutoIndex())
-      jtsGeom.index();
     return jtsGeom;
   }
 
@@ -520,7 +518,11 @@ public class JtsShapeFactory extends ShapeFactoryImpl {
    * @param allowMultiOverlap See {@link #isAllowMultiOverlap()}.
    */
   public JtsGeometry makeShape(Geometry geom, boolean dateline180Check, boolean allowMultiOverlap) {
-    return new JtsGeometry(geom, (JtsSpatialContext) ctx, dateline180Check, allowMultiOverlap);
+    JtsGeometry jtsGeom = new JtsGeometry(geom, (JtsSpatialContext) ctx, dateline180Check, allowMultiOverlap);
+    if (isAutoIndex()) {
+      jtsGeom.index();
+    }
+    return jtsGeom;
   }
 
   /**

--- a/src/test/java/org/locationtech/spatial4j/shape/jts/JtsShapeFactoryTest.java
+++ b/src/test/java/org/locationtech/spatial4j/shape/jts/JtsShapeFactoryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.spatial4j.shape.jts;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import org.junit.Test;
+import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
+import org.locationtech.spatial4j.context.jts.JtsSpatialContextFactory;
+
+import static org.junit.Assert.assertTrue;
+
+public class JtsShapeFactoryTest {
+
+  @Test
+  public void testIndex() {
+
+    JtsSpatialContextFactory ctxFactory = new JtsSpatialContextFactory();
+    ctxFactory.autoIndex = true;
+
+    Geometry g = ctxFactory.getGeometryFactory().createPoint(new Coordinate(0,0)).buffer(0.1);
+
+    JtsSpatialContext ctx = ctxFactory.newSpatialContext();
+
+    JtsGeometry jtsGeom1 = (JtsGeometry) ctx.getShapeFactory().makeShapeFromGeometry(g);
+    assertTrue(jtsGeom1.isIndexed());
+
+    JtsGeometry jtsGeom2 = ctx.getShapeFactory().makeShape(g);
+    assertTrue(jtsGeom2.isIndexed());
+  }
+}


### PR DESCRIPTION
Prior to this change the auto index flag is respected only if makeShapeFromGeometry() is called. This moves the auto index check more central so that it applies when makeShape() is called.
