### PR TITLE
Add pointLatLon convenience method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.5.201505241946</version>
+        <version>0.8.2</version>
         <executions>
           <execution>
             <id>prepare-agent</id>

--- a/src/main/java/org/locationtech/spatial4j/io/OnePointsBuilder.java
+++ b/src/main/java/org/locationtech/spatial4j/io/OnePointsBuilder.java
@@ -34,6 +34,13 @@ public class OnePointsBuilder implements ShapeFactory.PointsBuilder<OnePointsBui
     return this;
   }
 
+  @Override
+  public OnePointsBuilder pointLatLon(double latitude, double longitude) {
+    assert point == null;
+    point = shapeFactory.pointLatLon(latitude, longitude);
+    return this;
+  }
+
   public Point getPoint() {
     return point;
   }

--- a/src/main/java/org/locationtech/spatial4j/shape/Point.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/Point.java
@@ -27,4 +27,10 @@ public interface Point extends Shape {
   /** The Y coordinate, or Latitude in geospatial contexts. */
   public double getY();
 
+  /** Convenience method that usually maps on {@link org.locationtech.spatial4j.shape.Point#getY()} */
+  public double getLat();
+
+  /** Convenience method that usually maps on {@link org.locationtech.spatial4j.shape.Point#getX()} */
+  public double getLon();
+
 }

--- a/src/main/java/org/locationtech/spatial4j/shape/ShapeFactory.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/ShapeFactory.java
@@ -59,6 +59,9 @@ public interface ShapeFactory {
   /** Construct a point. */
   Point pointXY(double x, double y);
 
+  /** Construct a point of latitude, longitude coordinates */
+  Point pointLatLon(double latitude, double longitude);
+
   /** Construct a point of 3 dimensions.  The implementation might ignore unsupported
    * dimensions like 'z' or throw an error. */
   Point pointXYZ(double x, double y, double z);
@@ -129,6 +132,8 @@ public interface ShapeFactory {
     T pointXY(double x, double y);
     /** @see ShapeFactory#pointXYZ(double, double, double) */
     T pointXYZ(double x, double y, double z);
+    /** @see ShapeFactory#pointLatLon(double, double)  */
+    T pointLatLon(double latitude, double longitude);
   }
 
   /** @see #lineString() */

--- a/src/main/java/org/locationtech/spatial4j/shape/impl/PointImpl.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/impl/PointImpl.java
@@ -51,6 +51,16 @@ public class PointImpl extends BaseShape<SpatialContext> implements Point {
   }
 
   @Override
+  public double getLat() {
+    return getY();
+  }
+
+  @Override
+  public double getLon() {
+    return getX();
+  }
+
+  @Override
   public Rectangle getBoundingBox() {
     return ctx.makeRectangle(this, this);
   }

--- a/src/main/java/org/locationtech/spatial4j/shape/impl/ShapeFactoryImpl.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/impl/ShapeFactoryImpl.java
@@ -83,6 +83,13 @@ public class ShapeFactoryImpl implements ShapeFactory {
   }
 
   @Override
+  public Point pointLatLon(double latitude, double longitude) {
+    verifyX(longitude);
+    verifyY(latitude);
+    return new PointImpl(longitude, latitude, ctx);
+  }
+
+  @Override
   public Point pointXYZ(double x, double y, double z) {
     return pointXY(x, y); // or throw?
   }
@@ -174,6 +181,12 @@ public class ShapeFactoryImpl implements ShapeFactory {
       }
 
       @Override
+      public LineStringBuilder pointLatLon(double latitude, double longitude) {
+        points.add(ShapeFactoryImpl.this.pointLatLon(latitude, longitude));
+        return this;
+      }
+
+      @Override
       public Shape build() {
         return new BufferedLineString(points, bufferDistance, false, ctx);
       }
@@ -229,6 +242,12 @@ public class ShapeFactoryImpl implements ShapeFactory {
     @Override
     public MultiPointBuilder pointXYZ(double x, double y, double z) {
       shapes.add(ShapeFactoryImpl.this.pointXYZ(x, y, z));
+      return this;
+    }
+
+    @Override
+    public MultiPointBuilder pointLatLon(double latitude, double longitude) {
+      shapes.add(ShapeFactoryImpl.this.pointLatLon(latitude, longitude));
       return this;
     }
 

--- a/src/main/java/org/locationtech/spatial4j/shape/jts/JtsPoint.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/jts/JtsPoint.java
@@ -88,6 +88,16 @@ public class JtsPoint extends BaseShape<JtsSpatialContext> implements Point {
   }
 
   @Override
+  public double getLat() {
+    return getY();
+  }
+
+  @Override
+  public double getLon() {
+    return getX();
+  }
+
+  @Override
   public void reset(double x, double y) {
     assert ! isEmpty();
     CoordinateSequence cSeq = pointGeom.getCoordinateSequence();

--- a/src/main/java/org/locationtech/spatial4j/shape/jts/JtsShapeFactory.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/jts/JtsShapeFactory.java
@@ -320,6 +320,9 @@ public class JtsShapeFactory extends ShapeFactoryImpl {
       return getThis();
     }
 
+    public T pointLatLon(double latitude, double longitude) {
+      return pointXYZ(longitude, latitude, Coordinate.NULL_ORDINATE);
+    }
     // TODO would be be useful to add other ways of providing points?  e.g. point(Coordinate)?
 
     // TODO consider wrapping the List<Coordinate> in a custom CoordinateSequence and then (conditionally) use

--- a/src/test/java/org/locationtech/spatial4j/distance/TestDistances.java
+++ b/src/test/java/org/locationtech/spatial4j/distance/TestDistances.java
@@ -322,7 +322,7 @@ public class TestDistances extends RandomizedTest {
   }
 
   private Point pLL(double lat, double lon) {
-    return ctx.makePoint(lon,lat);
+    return ctx.getShapeFactory().pointLatLon(lat, lon);
   }
 
   @Test


### PR DESCRIPTION
This pull requests adds a pointLatLon convenience method as proposed in #164 . 

I also noticed that the project cannot be build with Maven and Java 9 due to the error described [here](https://discuss.gradle.org/t/jacoco-plugin-does-not-work-with-java-9/18157). Thus, I bumped the JaCoCo plugin version to 0.8.2 which is the newest one available.

EDIT: I can squash the commits if necessary.