### PR TITLE
Add possibility to overwrite WKTWriter NumberFormat

### DIFF
--- a/src/main/java/org/locationtech/spatial4j/io/WKTWriter.java
+++ b/src/main/java/org/locationtech/spatial4j/io/WKTWriter.java
@@ -33,10 +33,14 @@ public class WKTWriter implements ShapeWriter {
   protected StringBuilder append(StringBuilder buffer, Point p, NumberFormat nf) {
     return buffer.append(nf.format(p.getX())).append(' ').append( nf.format(p.getY()));
   }
-  
+
+  protected NumberFormat getNumberFormat() {
+    return LegacyShapeWriter.makeNumberFormat(6);
+  }
+
   @Override
   public String toString(Shape shape) {
-    NumberFormat nf = LegacyShapeWriter.makeNumberFormat(6);
+    NumberFormat nf = getNumberFormat();
     if (shape instanceof Point) {
       StringBuilder buffer = new StringBuilder();
       return append(buffer.append("POINT ("),(Point)shape,nf).append(")").toString();


### PR DESCRIPTION
Because of #140 , it can be necessary to extend a writer to customize the used NumberFormat until a more general (configuration) solution is available.

This pull requests aims to simplify the customize procedure. E.g., find below how I overwrite the WKTWriter so that it does not round the written values at all:

```Java
public class WKTWriter extends JtsWKTWriter {

	public WKTWriter(JtsSpatialContext ctx, JtsSpatialContextFactory factory) {
		super(ctx, factory);
	}

	/**
	 * Same as {@link org.locationtech.spatial4j.io.LegacyShapeWriter#makeNumberFormat(int)}, 
	 * but does not remove fraction digits
	 */
	@Override
	protected NumberFormat getNumberFormat() {
		NumberFormat nf = NumberFormat.getInstance(Locale.ROOT);//not thread-safe
		nf.setGroupingUsed(false);
		nf.setMaximumFractionDigits(20); // maximum double is ~16, so we are fine with 20
		nf.setMinimumFractionDigits(0);
		return nf;
	}
}
```

The new writer can be added like so:
```Java
public static final JtsSpatialContext GEO;
static {
	JtsSpatialContextFactory factory = new JtsSpatialContextFactory();
	factory.geo = true;
	factory.writers.clear();
	factory.writers.add(WKTWriter.class);
	GEO = new JtsSpatialContext(factory);
}
```