### PR TITLE
locationtech/spatial4j#168 removed eclipse-jarsigner-plugin and added…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,45 +427,22 @@
               </execution>
             </executions>
           </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- For signing artifacts to eventually be used in a release.  Should be used in conjunction with the
-    "release" profile.
-    Note this plugin only works from Eclipse infrastructure (e.g. Hudson) -->
-    <profile>
-      <id>eclipse-sign</id>
-      <build>
-        <plugins>
-          <!--
-          https://www.eclipse.org/cbi/maven-plugins/documentation/latest/eclipse-jarsigner-plugin/sign-mojo.html
-          -->
           <plugin>
-            <groupId>org.eclipse.cbi.maven.plugins</groupId>
-            <artifactId>eclipse-jarsigner-plugin</artifactId>
-            <version>1.1.4</version>
-            <!--<configuration>-->
-              <!--<signerUrl>http://locationtech.org:31338/sign</signerUrl>-->
-            <!--</configuration>-->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
             <executions>
               <execution>
-                <id>sign</id>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>
-                <phase>verify</phase>
               </execution>
             </executions>
           </plugin>
         </plugins>
       </build>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>cbi-releases</id>
-          <url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
-        </pluginRepository>
-      </pluginRepositories>
     </profile>
 
   </profiles>


### PR DESCRIPTION
JAR signing is typically used downstream to verify that code hasn't been changed. The Java runtime verifies that that JAR has not been tampered with. When using fat-jars (which is very typical for deployment) the signatures don't match anymore. 

The maven-gpg-plugin also signs JARs, but instead of relying on the Java runtime to check those signatures, they are instead checked by maven on build-time. 

I've switch spatial4j from the previous mentioned JAR signing to the maven gpg plugin. This is what https://github.com/locationtech/jts uses.