### PR TITLE
Specify dist 'trusty' for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ script: mvn -Drandomized.multiplier=10 clean verify jacoco:report
 jdk:
   - openjdk7
   - oraclejdk8
+  - openjdk8
 #TODO  - oraclejdk9
+
+dist: trusty # Travis Xenial doesn't have oraclejdk8
 
 notifications:
   email:


### PR DESCRIPTION
The Xenial dist doesn't have oracle jdk8 and the builds are failing as a result.

Signed-off-by: Hrishi Bakshi <hrishi@amazon.com>