### PR TITLE
Add support for dateline wrapping for circle to geometry conversion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 DATE: _unreleased_
 
+* \#194: Circles that cross a dateline can now be converted to a JTS Geometry. Previous attempts would throw an exception. 
+ (Stijn Caerts)
+
+* \#194: JtsGeometry now supports input an Geometry that crosses the dateline multiple times (wraps the globe multiple times). Previous attempts would yield erroneous behavior.
+ (Stijn Caerts)
+
 * \#188: Upgraded to JTS 1.17.0.  This JTS release has a small [API change](https://github.com/locationtech/jts/blob/master/doc/JTS_Version_History.md#api-changes) and it requires Java 1.8.
   Spatial4J should work fine with older versions still.
   (Jim Hughes)

--- a/src/main/java/org/locationtech/spatial4j/shape/jts/JtsGeometry.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/jts/JtsGeometry.java
@@ -582,10 +582,13 @@ public class JtsGeometry extends BaseShape<JtsSpatialContext> {
         break;
       Geometry rect = geom.getFactory().toGeometry(new Envelope(minX, minX + 360, -90, 90));
       assert rect.isValid() : "rect";
-      Geometry pageGeom = rect.intersection(geom).copy();//JTS is doing some hard work
+      Geometry pageGeom = rect.intersection(geom);//JTS is doing some hard work
       assert pageGeom.isValid() : "pageGeom";
 
-      shiftGeomByX(pageGeom, page * -360);
+      if (page != 0) {
+        pageGeom = pageGeom.copy(); // because shiftGeomByX modifies the underlying coordinates shared by geom.
+        shiftGeomByX(pageGeom, page * -360);
+      }
       geomList.add(pageGeom);
     }
     return UnaryUnionOp.union(geomList);

--- a/src/main/java/org/locationtech/spatial4j/shape/jts/JtsGeometry.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/jts/JtsGeometry.java
@@ -573,17 +573,16 @@ public class JtsGeometry extends BaseShape<JtsSpatialContext> {
       return geom;
     assert geom.isValid() : "geom";
 
-    //TODO opt: support geom's that start at negative pages --
-    // ... will avoid need to previously shift in unwrapDateline(geom).
     List<Geometry> geomList = new ArrayList<Geometry>();
     //page 0 is the standard -180 to 180 range
-    for (int page = 0; true; page++) {
+    int startPage = (int) Math.floor((geomEnv.getMinX() + 180) / 360);
+    for (int page = startPage; true; page++) {
       double minX = -180 + page * 360;
       if (geomEnv.getMaxX() <= minX)
         break;
       Geometry rect = geom.getFactory().toGeometry(new Envelope(minX, minX + 360, -90, 90));
       assert rect.isValid() : "rect";
-      Geometry pageGeom = rect.intersection(geom);//JTS is doing some hard work
+      Geometry pageGeom = rect.intersection(geom).copy();//JTS is doing some hard work
       assert pageGeom.isValid() : "pageGeom";
 
       shiftGeomByX(pageGeom, page * -360);

--- a/src/main/java/org/locationtech/spatial4j/shape/jts/JtsShapeFactory.java
+++ b/src/main/java/org/locationtech/spatial4j/shape/jts/JtsShapeFactory.java
@@ -157,14 +157,16 @@ public class JtsShapeFactory extends ShapeFactoryImpl {
       //  http://docs.codehaus.org/display/GEOTDOC/01+How+to+Create+a+Geometry#01HowtoCreateaGeometry-CreatingaCircle
       //TODO This should ideally have a geodetic version
       Circle circle = (Circle)shape;
-      if (circle.getBoundingBox().getCrossesDateLine())
-        throw new IllegalArgumentException("Doesn't support dateline cross yet: "+circle);//TODO
       GeometricShapeFactory gsf = new GeometricShapeFactory(geometryFactory);
       gsf.setWidth(circle.getBoundingBox().getWidth());
       gsf.setHeight(circle.getBoundingBox().getHeight());
       gsf.setNumPoints(4*25);//multiple of 4 is best
       gsf.setCentre(new Coordinate(circle.getCenter().getX(), circle.getCenter().getY()));
-      return gsf.createCircle();
+      Geometry geom = gsf.createCircle();
+      if (circle.getBoundingBox().getCrossesDateLine())
+        // wrap the geometry in a JtsGeometry to handle date line wrapping
+        geom = new JtsGeometry(geom, (JtsSpatialContext) getSpatialContext(),false, false).getGeom();
+      return geom;
     }
     //TODO add BufferedLineString
     throw new InvalidShapeException("can't make Geometry from: " + shape);

--- a/src/test/java/org/locationtech/spatial4j/context/jts/JtsSpatialContextTest.java
+++ b/src/test/java/org/locationtech/spatial4j/context/jts/JtsSpatialContextTest.java
@@ -13,6 +13,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.spatial4j.shape.jts.JtsGeometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.MultiPolygon;
 import org.junit.Test;
 import org.locationtech.spatial4j.shape.jts.JtsShapeFactory;
 import org.locationtech.spatial4j.util.Geom;
@@ -61,5 +62,21 @@ public class JtsSpatialContextTest {
                 "((179 90, 180 90, 180 -90, 179 -90, 179 90)), " +
                 "((0 0, 1 1, 1 0, 0 0))" +
                 ")", jtsGeometry.toString());
+    }
+
+    @Test
+    public void testMultiDatelineWrap() {
+        // polygon crosses the dateline twice
+        Polygon polygon = Geom.build().points(-179, 45, 179, 44, 1, 35, -179, 25, 179, 24, 179, 19, -179, 20, 1, 30, 179, 39, -179, 40).toPolygon();
+
+        JtsSpatialContextFactory factory = new JtsSpatialContextFactory();
+        factory.datelineRule = DatelineRule.width180;
+        JtsSpatialContext ctx = factory.newSpatialContext();
+        JtsShapeFactory shapeFactory = ctx.getShapeFactory();
+        JtsGeometry jtsGeometry = shapeFactory.makeShape(polygon);
+        Geometry geometry = jtsGeometry.getGeom();
+
+        assertTrue(geometry.isValid());
+        assertTrue(geometry instanceof MultiPolygon);
     }
 }


### PR DESCRIPTION
Added support for dateline wrapping when converting a circle to a geometry. I implemented it like this;
- support geometries that start at negative pages in `JtsGeometry::cutUnwrappedGeomInto360()`
- put the geometry of the circle in a `JtsGeometry` if the circle crosses the dateline