### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: java
 sudo: false
 
 script: mvn -Drandomized.multiplier=10 clean verify jacoco:report
-
+arch:
+  - amd64
+  - ppc64le
 jdk:
   - oraclejdk8
   - openjdk8


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM. The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/spatial4j/builds/209314428 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!