### PR TITLE
Update JTS to 18.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## VERSION X.X
 
-(TBD)
+* \#206: Upgraded to JTS 1.18.1.  This JTS release had an incompatible [API change](https://github.com/locationtech/jts/blob/master/doc/JTS_Version_History.md#api-changes) and it requires Java 1.8.
+  Spatial4J will not work anymore with older versions.
+(Christian Marsch)
 
 ## VERSION 0.8
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
-      <version>1.17.0</version>
+      <version>1.18.1</version>
       <optional>true</optional>
     </dependency>
     

--- a/src/main/java/org/locationtech/spatial4j/io/jts/JtsBinaryCodec.java
+++ b/src/main/java/org/locationtech/spatial4j/io/jts/JtsBinaryCodec.java
@@ -85,15 +85,17 @@ public class JtsBinaryCodec extends BinaryCodec {
       InStream inStream = new InStream() {//a strange JTS abstraction
         boolean first = true;
         @Override
-        public void read(byte[] buf) throws IOException {
+        public int read(byte[] buf) throws IOException {
           if (first) {//we don't write JTS's leading BOM so synthesize reading it
             if (buf.length != 1)
               throw new IllegalStateException("Expected initial read of one byte, not: " + buf.length);
             buf[0] = WKBConstants.wkbXDR;//0
             first = false;
+            return 1;
           } else {
             //TODO for performance, specialize for common array lengths: 1, 4, 8
             dataInput.readFully(buf);
+            return buf.length;
           }
         }
       };


### PR DESCRIPTION
Related to issue https://github.com/locationtech/spatial4j/issues/205, this will bump JTS to 18.1, applying a minor change in org.locationtech.spatial4j.io.jts.JtsBinaryCodec.readJtsGeom(DataInput)